### PR TITLE
make NUM_PARSERS and PARSE_CHUNK_SIZE configurable

### DIFF
--- a/main.go
+++ b/main.go
@@ -11,6 +11,7 @@ import (
 	"runtime"
 	"runtime/pprof"
 	"sort"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -18,23 +19,28 @@ import (
 )
 
 // go run main.go [measurements_file]
+// tune env vars for performance
+//
+// Environment variables:
+// - NUM_PARSERS:         number of parsers to run concurrently. if unset, defaults
+//   			          to runtime.NumCPU()
+// - PARSE_CHUNK_SIZE_MB: size of each chunk to parse. if unset, defaults to
+//                        defaultParseChunkSize
+// - PROFILE:             if "true", enables profiling
 
 var (
-	// Optional env vars
-	shouldProfile = os.Getenv("PROFILE") == "true"
-
-	defaultMeasurementsPath = "measurements.txt"
 	// others: "heap", "threadcreate", "block", "mutex"
 	profileTypes = []string{"goroutine", "allocs"}
 )
 
 const (
-	maxNameLen = 100
-	maxNameNum = 10000
+	defaultMeasurementsPath = "measurements.txt"
+	maxNameLen              = 100
+	maxNameNum              = 10000
 
-	// Tune these for performance
-	minNumParsers  = 12 // currently configured to the number of runtime.NumCPU()
-	parseChunkSize = 256 * 1024 * 1024
+	// tuned for a 2023 Macbook M2 Pro
+	defaultParseChunkSizeMB = 64
+	mb                      = 1024 * 1024 // bytes
 )
 
 type Stats struct {
@@ -176,11 +182,39 @@ func printResults(stats map[string]*Stats) { // doesn't help
 // offset chan and send results on an output chan. The results are merged into a
 // single map of stats and printed.
 func main() {
+	// parse env vars and inputs
+	shouldProfile := os.Getenv("PROFILE") == "true"
+	var err error
+	var numParsers int
+	{
+		if os.Getenv("NUM_PARSERS") != "" {
+			numParsers, err = strconv.Atoi(os.Getenv("NUM_PARSERS"))
+			if err != nil {
+				log.Fatal(fmt.Errorf("failed to parse NUM_PARSERS: %w", err))
+			}
+		} else {
+			numParsers = runtime.NumCPU()
+		}
+	}
+	var parseChunkSize int
+	{
+		if os.Getenv("PARSE_CHUNK_SIZE_MB") != "" {
+			parseChunkSizeMB, err := strconv.Atoi(os.Getenv("PARSE_CHUNK_SIZE_MB"))
+			if err != nil {
+				log.Fatal(fmt.Errorf("failed to parse PARSE_CHUNK_SIZE_MB: %w", err))
+			}
+			parseChunkSize = parseChunkSizeMB * mb
+		} else {
+			parseChunkSize = defaultParseChunkSizeMB * mb
+		}
+	}
+
 	measurementsPath := defaultMeasurementsPath
 	if len(os.Args) > 1 {
 		measurementsPath = os.Args[1]
 	}
 
+	// profile code
 	if shouldProfile {
 		nowUnix := time.Now().Unix()
 		os.MkdirAll(fmt.Sprintf("profiles/%d", nowUnix), 0755)
@@ -211,11 +245,6 @@ func main() {
 	}
 
 	// kick off "parser" workers
-	numParsers := runtime.NumCPU()
-	if minNumParsers > numParsers {
-		numParsers = minNumParsers
-	}
-
 	wg := sync.WaitGroup{}
 	wg.Add(numParsers)
 


### PR DESCRIPTION
update defaultParseChunkSizeMB based on parameterized testing

```
Benchmark 4: PARSE_CHUNK_SIZE_MB=64 NUM_PARSERS=10 ./bin/1brc-go 2>&1
  Time (mean ± σ):      5.399 s ±  0.039 s    [User: 38.465 s, System: 1.791 s]
  Range (min … max):    5.355 s …  5.429 s    3 runs
```

## Testing

64 MB is best for read buffer size
```
Summary
  PARSE_CHUNK_SIZE_MB=64 ./bin/1brc-go 2>&1 ran
    1.05 ± 0.03 times faster than PARSE_CHUNK_SIZE_MB=1 ./bin/1brc-go 2>&1
    1.06 ± 0.02 times faster than PARSE_CHUNK_SIZE_MB=128 ./bin/1brc-go 2>&1
    1.26 ± 0.02 times faster than PARSE_CHUNK_SIZE_MB=256 ./bin/1brc-go 2>&1
    1.38 ± 0.03 times faster than PARSE_CHUNK_SIZE_MB=512 ./bin/1brc-go 2>&1
    3.12 ± 0.31 times faster than PARSE_CHUNK_SIZE_MB=1024 ./bin/1brc-go 2>&1
```

NumCPU and greater all perform the same. Just default to NumCPU
```
Summary
  PARSE_CHUNK_SIZE_MB=64 NUM_PARSERS=16 ./bin/1brc-go 2>&1 ran
    1.00 ± 0.02 times faster than PARSE_CHUNK_SIZE_MB=64 NUM_PARSERS=12 ./bin/1brc-go 2>&1
    1.00 ± 0.02 times faster than PARSE_CHUNK_SIZE_MB=64 NUM_PARSERS=14 ./bin/1brc-go 2>&1
    1.01 ± 0.02 times faster than PARSE_CHUNK_SIZE_MB=64 NUM_PARSERS=10 ./bin/1brc-go 2>&1
    1.01 ± 0.02 times faster than PARSE_CHUNK_SIZE_MB=64 NUM_PARSERS=24 ./bin/1brc-go 2>&1
    1.15 ± 0.02 times faster than PARSE_CHUNK_SIZE_MB=64 NUM_PARSERS=8 ./bin/1brc-go 2>&1
    1.30 ± 0.02 times faster than PARSE_CHUNK_SIZE_MB=64 NUM_PARSERS=6 ./bin/1brc-go 2>&1
    6.45 ± 0.11 times faster than PARSE_CHUNK_SIZE_MB=64 NUM_PARSERS=1 ./bin/1brc-go 2>&1
```